### PR TITLE
Fix: common usecase and docs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - godox
     - goheader
     - gomoddirectives
     - gomodguard
@@ -64,6 +63,7 @@ linters:
     - contextcheck
     - cyclop
     - depguard
+    - godox
     - durationcheck
     - exhaustruct
     - ineffassign

--- a/cmd/watchtower/watchtower.go
+++ b/cmd/watchtower/watchtower.go
@@ -22,7 +22,12 @@ import (
 // @description    Watchtower is a project designed to provide processing files created into cloud by events.
 //
 // @tag.name tasks
-// @tag.description APIs to get status tasks. When TaskStatus may be: Failed -> -1; Received -> 0; Pending -> 1; Processing -> 2; Successful -> 3.
+// @tag.description APIs to get status tasks. When TaskStatus may be:
+// 	Failed -> -1;
+//	Received -> 0;
+//	Pending -> 1;
+//	Processing -> 2;
+//	Successful -> 3.
 //
 // @tag.name buckets
 // @tag.description CRUD APIs to manage cloud buckets

--- a/cmd/watchtower/watchtower.go
+++ b/cmd/watchtower/watchtower.go
@@ -22,7 +22,7 @@ import (
 // @description    Watchtower is a project designed to provide processing files created into cloud by events.
 //
 // @tag.name tasks
-// @tag.description APIs to get status tasks
+// @tag.description APIs to get status tasks. When TaskStatus may be: Failed -> -1; Received -> 0; Pending -> 1; Processing -> 2; Successful -> 3.
 //
 // @tag.name buckets
 // @tag.description CRUD APIs to manage cloud buckets

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -505,7 +505,7 @@ const docTemplate = `{
             }
         },
         "/cloud/{bucket}/file/upload": {
-            "post": {
+            "put": {
                 "description": "Upload files to cloud",
                 "consumes": [
                     "multipart/form"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -891,7 +891,7 @@ const docTemplate = `{
     },
     "tags": [
         {
-            "description": "APIs to get status tasks",
+            "description": "APIs to get status tasks. When TaskStatus may be: Failed -\u003e -1; Received -\u003e 0; Pending -\u003e 1; Processing -\u003e 2; Successful -\u003e 3.",
             "name": "tasks"
         },
         {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -883,7 +883,7 @@
     },
     "tags": [
         {
-            "description": "APIs to get status tasks",
+            "description": "APIs to get status tasks. When TaskStatus may be: Failed -\u003e -1; Received -\u003e 0; Pending -\u003e 1; Processing -\u003e 2; Successful -\u003e 3.",
             "name": "tasks"
         },
         {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -497,7 +497,7 @@
             }
         },
         "/cloud/{bucket}/file/upload": {
-            "post": {
+            "put": {
                 "description": "Upload files to cloud",
                 "consumes": [
                     "multipart/form"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -594,7 +594,8 @@ paths:
       - tasks
 swagger: "2.0"
 tags:
-- description: APIs to get status tasks
+- description: 'APIs to get status tasks. When TaskStatus may be: Failed -> -1; Received
+    -> 0; Pending -> 1; Processing -> 2; Successful -> 3.'
   name: tasks
 - description: CRUD APIs to manage cloud buckets
   name: buckets

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -396,7 +396,7 @@ paths:
       tags:
       - share
   /cloud/{bucket}/file/upload:
-    post:
+    put:
       consumes:
       - multipart/form
       description: Upload files to cloud

--- a/internal/application/usecase/usecase.go
+++ b/internal/application/usecase/usecase.go
@@ -56,10 +56,11 @@ func (uc *UseCase) LaunchWatcherListener(ctx context.Context) {
 			select {
 			case taskEvent := <-uc.processorCh:
 				// TODO: Disabled for TechDebt
-				//if uc.isTaskAlreadyProcessed(ctx, &taskEvent) {
-				//	log.Printf("task has been already processed: %s", taskEvent.ID)
-				//	continue
-				//}
+				_ = uc.isTaskAlreadyProcessed(ctx, &taskEvent)
+				// if uc.isTaskAlreadyProcessed(ctx, &taskEvent) {
+				//	 log.Printf("task has been already processed: %s", taskEvent.ID)
+				//	 continue
+				// }
 
 				status, msg := dto.Pending, EmptyMessage
 				if err := uc.publishToQueue(ctx, taskEvent); err != nil {
@@ -160,13 +161,13 @@ func (uc *UseCase) processFile(ctx context.Context, taskEvent dto.TaskEvent) (st
 		ModifiedAt: taskEvent.ModifiedAt,
 	}
 
-	id, err := uc.docStorage.StoreDocument(ctx, taskEvent.Bucket, doc)
+	docID, err := uc.docStorage.StoreDocument(ctx, taskEvent.Bucket, doc)
 	if err != nil {
 		return "", fmt.Errorf("failed to store doc %s: %w", doc.FileName, err)
 	}
 
-	log.Printf("successfully stored document: %s", id)
-	return id, nil
+	log.Printf("successfully stored document: %s", docID)
+	return docID, nil
 }
 
 func (uc *UseCase) StoreFileToStorage(ctx context.Context, fileForm dto.FileToUpload) (*dto.TaskEvent, error) {

--- a/internal/application/usecase/usecase.go
+++ b/internal/application/usecase/usecase.go
@@ -55,10 +55,11 @@ func (uc *UseCase) LaunchWatcherListener(ctx context.Context) {
 		for {
 			select {
 			case taskEvent := <-uc.processorCh:
-				if uc.isTaskAlreadyProcessed(ctx, &taskEvent) {
-					log.Printf("task has been already processed: %s", taskEvent.ID)
-					continue
-				}
+				// TODO: Disabled for TechDebt
+				//if uc.isTaskAlreadyProcessed(ctx, &taskEvent) {
+				//	log.Printf("task has been already processed: %s", taskEvent.ID)
+				//	continue
+				//}
 
 				status, msg := dto.Pending, EmptyMessage
 				if err := uc.publishToQueue(ctx, taskEvent); err != nil {
@@ -68,13 +69,7 @@ func (uc *UseCase) LaunchWatcherListener(ctx context.Context) {
 
 				uc.updateTaskStatus(ctx, &taskEvent, status, msg)
 			case cMsg := <-uc.consumerCh:
-				status, msg := dto.Successful, EmptyMessage
-				if err := uc.Processing(ctx, cMsg); err != nil {
-					status, msg = dto.Failed, err.Error()
-					log.Printf("failed while processing file: %v", err)
-				}
-
-				uc.updateTaskStatus(ctx, &cMsg.Body, status, msg)
+				uc.Processing(ctx, cMsg)
 			case <-ctx.Done():
 				log.Println("terminated processing")
 				return
@@ -83,11 +78,19 @@ func (uc *UseCase) LaunchWatcherListener(ctx context.Context) {
 	}()
 }
 
-func (uc *UseCase) Processing(ctx context.Context, msg dto.Message) error {
-	taskEvent := msg.Body
+func (uc *UseCase) Processing(ctx context.Context, recvMsg dto.Message) {
+	taskEvent := recvMsg.Body
 	uc.updateTaskStatus(ctx, &taskEvent, dto.Processing, EmptyMessage)
-	err := uc.processFile(ctx, taskEvent)
-	return err
+
+	status := dto.Successful
+	msg, err := uc.processFile(ctx, recvMsg.Body)
+	if err != nil {
+		status, msg = dto.Failed, err.Error()
+		log.Printf("failed while processing file: %v", err)
+	}
+
+	taskEvent.StatusText = msg
+	uc.updateTaskStatus(ctx, &taskEvent, status, msg)
 }
 
 func (uc *UseCase) publishToQueue(ctx context.Context, taskEvent dto.TaskEvent) error {
@@ -133,10 +136,10 @@ func (uc *UseCase) isTaskAlreadyProcessed(ctx context.Context, task *dto.TaskEve
 	}
 }
 
-func (uc *UseCase) processFile(ctx context.Context, taskEvent dto.TaskEvent) error {
+func (uc *UseCase) processFile(ctx context.Context, taskEvent dto.TaskEvent) (string, error) {
 	fileData, err := uc.objStorage.DownloadFile(ctx, taskEvent.Bucket, taskEvent.FilePath)
 	if err != nil {
-		return fmt.Errorf("failed to download file: %w", err)
+		return "", fmt.Errorf("failed to download file: %w", err)
 	}
 
 	inputFile := dto.InputFile{
@@ -145,7 +148,7 @@ func (uc *UseCase) processFile(ctx context.Context, taskEvent dto.TaskEvent) err
 	}
 	recData, err := uc.recognizer.Recognize(ctx, inputFile)
 	if err != nil {
-		return fmt.Errorf("failed to recognize: %w", err)
+		return "", fmt.Errorf("failed to recognize: %w", err)
 	}
 
 	doc := &dto.DocumentObject{
@@ -159,11 +162,11 @@ func (uc *UseCase) processFile(ctx context.Context, taskEvent dto.TaskEvent) err
 
 	id, err := uc.docStorage.StoreDocument(ctx, taskEvent.Bucket, doc)
 	if err != nil {
-		return fmt.Errorf("failed to store doc %s: %w", doc.FileName, err)
+		return "", fmt.Errorf("failed to store doc %s: %w", doc.FileName, err)
 	}
 
 	log.Printf("successfully stored document: %s", id)
-	return nil
+	return id, nil
 }
 
 func (uc *UseCase) StoreFileToStorage(ctx context.Context, fileForm dto.FileToUpload) (*dto.TaskEvent, error) {

--- a/internal/application/usecase/usecase.go
+++ b/internal/application/usecase/usecase.go
@@ -118,13 +118,13 @@ func (uc *UseCase) isTaskAlreadyProcessed(ctx context.Context, task *dto.TaskEve
 	}
 
 	switch storageTask.Status {
+	case dto.Received:
+		fallthrough
 	case dto.Pending:
 		fallthrough
 	case dto.Processing:
 		return true
 	case dto.Failed:
-		fallthrough
-	case dto.Received:
 		fallthrough
 	case dto.Successful:
 		return false

--- a/internal/application/utils/sender.go
+++ b/internal/application/utils/sender.go
@@ -45,7 +45,7 @@ func SendRequest(client *http.Client, req *http.Request) ([]byte, error) {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	if response.StatusCode > 200 {
+	if response.StatusCode/100 > 2 {
 		return nil, fmt.Errorf("non success response %s: %s", response.Status, string(respData))
 	}
 

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -89,7 +89,7 @@ func FromFile(filePath string) (*Config, error) {
 	}
 
 	// Storage doc-searcher config
-	bindErr = viperInstance.BindEnv("storage.docsearcher.address", "WATCHTOWER__DOCSTORAGE__DOC_SEARCHER__ADDRESS")
+	bindErr = viperInstance.BindEnv("docstorage.docsearcher.address", "WATCHTOWER__DOCSTORAGE__DOC_SEARCHER__ADDRESS")
 	if bindErr != nil {
 		return nil, fmt.Errorf("failed to bine env varialbe: %w", bindErr)
 	}

--- a/internal/infrastructure/doc-storage/doc-storage.go
+++ b/internal/infrastructure/doc-storage/doc-storage.go
@@ -54,13 +54,13 @@ func (dsc *DocSearcherClient) StoreDocument(
 
 	reqBody := bytes.NewBuffer(jsonData)
 	timeoutReq := time.Duration(300) * time.Second
-	_, err = utils.PUT(ctx, reqBody, targetURL, DocumentJsonMime, timeoutReq)
+	respData, err := utils.PUT(ctx, reqBody, targetURL, DocumentJsonMime, timeoutReq)
 	if err != nil {
 		return "", fmt.Errorf("failed to store document to storage: %w", err)
 	}
 
 	status := &StoreDocumentResult{}
-	err = json.Unmarshal(reqBody.Bytes(), status)
+	err = json.Unmarshal(respData, status)
 	if err != nil {
 		return "", fmt.Errorf("failed to unmarshal response body: %w", err)
 	}

--- a/internal/infrastructure/httpserver/routes_object.go
+++ b/internal/infrastructure/httpserver/routes_object.go
@@ -106,7 +106,7 @@ func (s *Server) MoveFile(eCtx echo.Context) error {
 // @Success 200 {object} ResponseForm "Ok"
 // @Failure	400 {object} BadRequestForm "Bad Request message"
 // @Failure	503 {object} ServerErrorForm "Server does not available"
-// @Router /cloud/{bucket}/file/upload [post]
+// @Router /cloud/{bucket}/file/upload [put]
 func (s *Server) UploadFile(eCtx echo.Context) error {
 	var fileData bytes.Buffer
 


### PR DESCRIPTION
There are following changes on `fix/common-pipelines-and-routers` branch:
 - updated logic to set id of stored document into task status text;
 - added description to task tag group about task status;
 - fixed checking status code logic;
 - fixed doc-search unmarshal response;
 - fixed config env parsing misprint;
 - updated swagger docs after all changes;
 - disabled checking task existing switch case logic (need fix).
