### PR TITLE
Improve: Add support force flag to store doc

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -870,28 +870,20 @@ const docTemplate = `{
         "httpserver.ShareFileForm": {
             "type": "object",
             "properties": {
-                "dir_path": {
-                    "type": "string",
-                    "example": "test-folder/"
-                },
                 "expired_secs": {
                     "type": "integer",
                     "example": 3600
                 },
-                "file_name": {
+                "file_path": {
                     "type": "string",
                     "example": "test-file.docx"
-                },
-                "redirect_host": {
-                    "type": "string",
-                    "example": "service-domain-name:4444"
                 }
             }
         }
     },
     "tags": [
         {
-            "description": "APIs to get status tasks. When TaskStatus may be: Failed -\u003e -1; Received -\u003e 0; Pending -\u003e 1; Processing -\u003e 2; Successful -\u003e 3.",
+            "description": "APIs to get status tasks. When TaskStatus may be:",
             "name": "tasks"
         },
         {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -862,28 +862,20 @@
         "httpserver.ShareFileForm": {
             "type": "object",
             "properties": {
-                "dir_path": {
-                    "type": "string",
-                    "example": "test-folder/"
-                },
                 "expired_secs": {
                     "type": "integer",
                     "example": 3600
                 },
-                "file_name": {
+                "file_path": {
                     "type": "string",
                     "example": "test-file.docx"
-                },
-                "redirect_host": {
-                    "type": "string",
-                    "example": "service-domain-name:4444"
                 }
             }
         }
     },
     "tags": [
         {
-            "description": "APIs to get status tasks. When TaskStatus may be: Failed -\u003e -1; Received -\u003e 0; Pending -\u003e 1; Processing -\u003e 2; Successful -\u003e 3.",
+            "description": "APIs to get status tasks. When TaskStatus may be:",
             "name": "tasks"
         },
         {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -100,17 +100,11 @@ definitions:
     type: object
   httpserver.ShareFileForm:
     properties:
-      dir_path:
-        example: test-folder/
-        type: string
       expired_secs:
         example: 3600
         type: integer
-      file_name:
+      file_path:
         example: test-file.docx
-        type: string
-      redirect_host:
-        example: service-domain-name:4444
         type: string
     type: object
 info:
@@ -594,8 +588,7 @@ paths:
       - tasks
 swagger: "2.0"
 tags:
-- description: 'APIs to get status tasks. When TaskStatus may be: Failed -> -1; Received
-    -> 0; Pending -> 1; Processing -> 2; Successful -> 3.'
+- description: 'APIs to get status tasks. When TaskStatus may be:'
   name: tasks
 - description: CRUD APIs to manage cloud buckets
   name: buckets

--- a/internal/application/services/object-storage/public.go
+++ b/internal/application/services/object-storage/public.go
@@ -31,7 +31,7 @@ type IFileManager interface {
 }
 
 type IShareManager interface {
-	GenSharedURL(ctx context.Context, expired time.Duration, bucket, filePath, redirect string) (string, error)
+	GenSharedURL(ctx context.Context, expired time.Duration, bucket, filePath string) (string, error)
 }
 
 type IFileLoader interface {

--- a/internal/application/usecase/usecase.go
+++ b/internal/application/usecase/usecase.go
@@ -81,6 +81,8 @@ func (uc *UseCase) LaunchWatcherListener(ctx context.Context) {
 
 func (uc *UseCase) Processing(ctx context.Context, recvMsg dto.Message) {
 	taskEvent := recvMsg.Body
+	log.Printf("processing task event: %v", taskEvent)
+
 	uc.updateTaskStatus(ctx, &taskEvent, dto.Processing, EmptyMessage)
 
 	status := dto.Successful
@@ -171,7 +173,9 @@ func (uc *UseCase) processFile(ctx context.Context, taskEvent dto.TaskEvent) (st
 }
 
 func (uc *UseCase) StoreFileToStorage(ctx context.Context, fileForm dto.FileToUpload) (*dto.TaskEvent, error) {
-	id := utils.GenerateUniqID(fileForm.Bucket, fileForm.FilePath)
+	// TODO: Disabled for TechDebt
+	// id := utils.GenerateUniqID(fileForm.Bucket, fileForm.FilePath)
+	id := utils.GenerateTaskID()
 	log.Printf("[%s]: publish task: %s", fileForm.Bucket, id)
 
 	task := dto.TaskEvent{

--- a/internal/application/utils/hasher.go
+++ b/internal/application/utils/hasher.go
@@ -3,7 +3,13 @@ package utils
 import (
 	"crypto/md5"
 	"fmt"
+
+	"github.com/google/uuid"
 )
+
+func GenerateTaskID() string {
+	return uuid.New().String()
+}
 
 func GenerateUniqID(bucket, suffix string) string {
 	mask := fmt.Sprintf("%s:%s", bucket, suffix)

--- a/internal/infrastructure/doc-storage/doc-storage.go
+++ b/internal/infrastructure/doc-storage/doc-storage.go
@@ -47,7 +47,7 @@ func (dsc *DocSearcherClient) StoreDocument(
 
 	buildURL := strings.Builder{}
 	buildURL.WriteString(dsc.config.Address)
-	buildURL.WriteString(fmt.Sprintf("/storage/%s/create", folder))
+	buildURL.WriteString(fmt.Sprintf("/storage/%s/create?force=true", folder))
 	targetURL := buildURL.String()
 
 	log.Printf("storing document to index %s", folder)

--- a/internal/infrastructure/httpserver/forms.go
+++ b/internal/infrastructure/httpserver/forms.go
@@ -52,10 +52,8 @@ type DownloadFileForm struct {
 
 // ShareFileForm example
 type ShareFileForm struct {
-	FileName     string `json:"file_name" example:"test-file.docx"`
-	FileDirPath  string `json:"dir_path" example:"test-folder/"`
-	ExpiredSecs  int32  `json:"expired_secs" example:"3600"`
-	RedirectHost string `json:"redirect_host" example:"service-domain-name:4444"`
+	FilePath    string `json:"file_path" example:"test-file.docx"`
+	ExpiredSecs int32  `json:"expired_secs" example:"3600"`
 }
 
 // GetFilesForm example

--- a/internal/infrastructure/httpserver/routes_object.go
+++ b/internal/infrastructure/httpserver/routes_object.go
@@ -338,17 +338,18 @@ func (s *Server) GetFileAttributes(eCtx echo.Context) error {
 func (s *Server) ShareFile(eCtx echo.Context) error {
 	bucket := eCtx.Param("bucket")
 
-	jsonForm := &ShareFileForm{}
+	form := &ShareFileForm{}
 	decoder := json.NewDecoder(eCtx.Request().Body)
-	err := decoder.Decode(jsonForm)
+	err := decoder.Decode(form)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	expired := time.Second * time.Duration(jsonForm.ExpiredSecs)
+	expired := time.Second * time.Duration(form.ExpiredSecs)
 
 	ctx := eCtx.Request().Context()
-	url, err := s.uc.GetObjectStorage().GenSharedURL(ctx, expired, bucket, jsonForm.FileName, jsonForm.RedirectHost)
+	storage := s.uc.GetObjectStorage()
+	url, err := storage.GenSharedURL(ctx, expired, bucket, form.FilePath)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}

--- a/internal/infrastructure/s3/s3.go
+++ b/internal/infrastructure/s3/s3.go
@@ -182,20 +182,11 @@ func (s *S3Client) UploadFile(
 	return nil
 }
 
-func (s *S3Client) GenSharedURL(
-	ctx context.Context,
-	expired time.Duration,
-	bucket, filePath, redirectHost string,
-) (string, error) {
+func (s *S3Client) GenSharedURL(ctx context.Context, expired time.Duration, bucket, filePath string) (string, error) {
 	url, err := s.mc.PresignedGetObject(ctx, bucket, filePath, expired, map[string][]string{})
 	if err != nil {
 		return "", fmt.Errorf("failed to generate url: %w", err)
 	}
 
-	if redirectHost != "" {
-		url.Path = fmt.Sprintf("%s%s", url.Host, url.Path)
-		url.Host = redirectHost
-	}
-
-	return url.String(), nil
+	return url.RequestURI(), nil
 }


### PR DESCRIPTION
There are following changes on `chore/support-force-flag-to-store-doc` branch:
 - added force flag supporting to store document;
 - re-impled share link to return relative shared file path;
 - updated swagger docs.
